### PR TITLE
Add support for Trinkets (if present) and add keybinding to open backpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,13 @@ minecraft {
 }
 
 repositories {
-
+    maven {
+        url = "https://jitpack.io"
+    }
+    maven {
+        name = "NerdHubMC"
+        url = "https://maven.abusedmaster.xyz/"
+    }
 }
 
 dependencies {
@@ -33,6 +39,9 @@ dependencies {
 
     modCompile "me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}"
     include "me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}"
+
+    // trinkets
+    modCompileOnly "com.github.emilyploszaj:trinkets:${project.trinkets_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@ auto_config_version=3.2.2
 universal_components_version=0.7.3+1.16.2
 cardinal_components_version=2.5.4
 cloth_config_version=4.8.1
+trinkets_version=2.6.7

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 minecraft_version=1.16.2
 yarn_mappings=1.16.2+build.43
 loader_version=0.9.2+build.206
-fabric_version=0.19.0+build.398-1.16
+fabric_version=0.29.3+1.16
 
 # Mod Properties
 mod_version=2.0.1-beta

--- a/src/main/java/draylar/inmis/Inmis.java
+++ b/src/main/java/draylar/inmis/Inmis.java
@@ -8,6 +8,7 @@ import draylar.inmis.config.InmisConfig;
 import draylar.inmis.content.BackpackItem;
 import draylar.inmis.content.EnderBackpackItem;
 import draylar.inmis.mixin.trinkets.TrinketsMixinPlugin;
+import draylar.inmis.network.ServerNetworking;
 import draylar.inmis.ui.BackpackScreenHandler;
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
 import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
@@ -38,6 +39,8 @@ public class Inmis implements ModInitializer {
         if (TrinketsMixinPlugin.isTrinketsLoaded) {
             TrinketSlots.addSlot(SlotGroups.CHEST, Slots.BACKPACK, new Identifier("trinkets", "textures/item/empty_trinket_slot_backpack.png"));
         }
+
+        ServerNetworking.init();
     }
 
     private void registerBackpacks() {

--- a/src/main/java/draylar/inmis/Inmis.java
+++ b/src/main/java/draylar/inmis/Inmis.java
@@ -1,9 +1,13 @@
 package draylar.inmis;
 
+import dev.emi.trinkets.api.SlotGroups;
+import dev.emi.trinkets.api.Slots;
+import dev.emi.trinkets.api.TrinketSlots;
 import draylar.inmis.config.BackpackInfo;
 import draylar.inmis.config.InmisConfig;
 import draylar.inmis.content.BackpackItem;
 import draylar.inmis.content.EnderBackpackItem;
+import draylar.inmis.mixin.trinkets.TrinketsMixinPlugin;
 import draylar.inmis.ui.BackpackScreenHandler;
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
 import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
@@ -30,6 +34,10 @@ public class Inmis implements ModInitializer {
     public void onInitialize() {
         Registry.register(Registry.ITEM, id("ender_pouch"), new EnderBackpackItem());
         registerBackpacks();
+
+        if (TrinketsMixinPlugin.isTrinketsLoaded) {
+            TrinketSlots.addSlot(SlotGroups.CHEST, Slots.BACKPACK, new Identifier("trinkets", "textures/item/empty_trinket_slot_backpack.png"));
+        }
     }
 
     private void registerBackpacks() {

--- a/src/main/java/draylar/inmis/InmisClient.java
+++ b/src/main/java/draylar/inmis/InmisClient.java
@@ -1,5 +1,6 @@
 package draylar.inmis;
 
+import draylar.inmis.client.InmisKeybinds;
 import draylar.inmis.ui.BackpackHandledScreen;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
@@ -12,5 +13,6 @@ public class InmisClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         ScreenRegistry.register(Inmis.CONTAINER_TYPE, BackpackHandledScreen::new);
+        InmisKeybinds.initialize();
     }
 }

--- a/src/main/java/draylar/inmis/client/InmisKeybinds.java
+++ b/src/main/java/draylar/inmis/client/InmisKeybinds.java
@@ -1,0 +1,29 @@
+package draylar.inmis.client;
+
+import draylar.inmis.network.ServerNetworking;
+import io.netty.buffer.Unpooled;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.client.options.KeyBinding;
+import net.minecraft.client.util.InputUtil;
+import net.minecraft.network.PacketByteBuf;
+import org.lwjgl.glfw.GLFW;
+
+public class InmisKeybinds {
+    private static KeyBinding openBackpackKeybinding;
+
+    public static void initialize() {
+        openBackpackKeybinding = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+                "key.inmis.open_backpack",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_GRAVE_ACCENT,
+                "category.inmis.keybindings"));
+
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (openBackpackKeybinding.wasPressed()) {
+                ClientPlayNetworking.send(ServerNetworking.OPEN_BACKPACK, new PacketByteBuf(Unpooled.buffer()));
+            }
+        });
+    }
+}

--- a/src/main/java/draylar/inmis/content/BackpackItem.java
+++ b/src/main/java/draylar/inmis/content/BackpackItem.java
@@ -29,27 +29,30 @@ public class BackpackItem extends Item {
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         user.setCurrentHand(hand);
+        openScreen(user, user.getStackInHand(hand));
 
-        if(world != null && !world.isClient) {
-            user.openHandledScreen(new ExtendedScreenHandlerFactory() {
+        return TypedActionResult.success(user.getStackInHand(hand));
+    }
+
+    public static void openScreen(PlayerEntity player, ItemStack backpackItemStack) {
+        if(player.world != null && !player.world.isClient) {
+            player.openHandledScreen(new ExtendedScreenHandlerFactory() {
                 @Override
                 public void writeScreenOpeningData(ServerPlayerEntity serverPlayerEntity, PacketByteBuf packetByteBuf) {
-                    packetByteBuf.writeEnumConstant(hand);
+                    packetByteBuf.writeItemStack(backpackItemStack);
                 }
-        
+
                 @Override
                 public Text getDisplayName() {
-                    return new TranslatableText(BackpackItem.this.getTranslationKey());
+                    return new TranslatableText(backpackItemStack.getItem().getTranslationKey());
                 }
-        
+
                 @Override
                 public @Nullable ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
-                    return new BackpackScreenHandler(syncId, inv, hand);
+                    return new BackpackScreenHandler(syncId, inv, backpackItemStack);
                 }
             });
         }
-
-        return TypedActionResult.success(user.getStackInHand(hand));
     }
 
     public BackpackInfo getTier() {

--- a/src/main/java/draylar/inmis/mixin/trinkets/BackpackItemTrinketMixin.java
+++ b/src/main/java/draylar/inmis/mixin/trinkets/BackpackItemTrinketMixin.java
@@ -1,0 +1,20 @@
+package draylar.inmis.mixin.trinkets;
+
+import dev.emi.trinkets.api.SlotGroups;
+import dev.emi.trinkets.api.Slots;
+import dev.emi.trinkets.api.Trinket;
+import draylar.inmis.content.BackpackItem;
+import net.minecraft.item.Item;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(BackpackItem.class)
+public abstract class BackpackItemTrinketMixin extends Item implements Trinket {
+    public BackpackItemTrinketMixin(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    public boolean canWearInSlot(String group, String slot) {
+        return group.equals(SlotGroups.CHEST) && slot.equals(Slots.BACKPACK);
+    }
+}

--- a/src/main/java/draylar/inmis/mixin/trinkets/TrinketsMixinPlugin.java
+++ b/src/main/java/draylar/inmis/mixin/trinkets/TrinketsMixinPlugin.java
@@ -1,0 +1,47 @@
+package draylar.inmis.mixin.trinkets;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class TrinketsMixinPlugin implements IMixinConfigPlugin {
+    private static final String TRINKETS_MOD_ID = "trinkets";
+
+    public static boolean isTrinketsLoaded = false;
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        isTrinketsLoaded = FabricLoader.getInstance().isModLoaded(TRINKETS_MOD_ID);
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return isTrinketsLoaded;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/draylar/inmis/network/ServerNetworking.java
+++ b/src/main/java/draylar/inmis/network/ServerNetworking.java
@@ -1,0 +1,50 @@
+package draylar.inmis.network;
+
+import dev.emi.trinkets.api.SlotGroups;
+import dev.emi.trinkets.api.Slots;
+import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.api.TrinketsApi;
+import draylar.inmis.Inmis;
+import draylar.inmis.content.BackpackItem;
+import draylar.inmis.mixin.trinkets.TrinketsMixinPlugin;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+import java.util.stream.Stream;
+
+public class ServerNetworking {
+    public static Identifier OPEN_BACKPACK = Inmis.id("open_backpack");
+
+    public static void init() {
+        registerOpenBackpackPacketHandler();
+    }
+
+    private static void registerOpenBackpackPacketHandler() {
+        ServerPlayNetworking.registerGlobalReceiver(OPEN_BACKPACK, ServerNetworking::receiveOpenBackpackPacket);
+    }
+
+    private static void receiveOpenBackpackPacket(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
+        if (TrinketsMixinPlugin.isTrinketsLoaded) {
+            TrinketComponent trinketComponent = TrinketsApi.getTrinketComponent(player);
+            ItemStack backpackSlotItemStack = trinketComponent.getStack(SlotGroups.CHEST, Slots.BACKPACK);
+            if (backpackSlotItemStack != ItemStack.EMPTY && backpackSlotItemStack.getItem() instanceof BackpackItem) {
+                BackpackItem.openScreen(player, backpackSlotItemStack);
+                return;
+            }
+        }
+
+        ItemStack firstBackpackItemStack = Stream.concat(player.inventory.offHand.stream(), player.inventory.main.stream())
+                .filter((itemStack) -> itemStack.getItem() instanceof BackpackItem)
+                .findFirst()
+                .orElse(ItemStack.EMPTY);
+        if (firstBackpackItemStack != ItemStack.EMPTY) {
+            BackpackItem.openScreen(player, firstBackpackItemStack);
+        }
+    }
+}

--- a/src/main/java/draylar/inmis/ui/BackpackScreenHandler.java
+++ b/src/main/java/draylar/inmis/ui/BackpackScreenHandler.java
@@ -16,30 +16,26 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
-import net.minecraft.util.Hand;
 
 public class BackpackScreenHandler extends ScreenHandler {
 
     public static final int BACKPACK_INVENTORY = 1;
-    private PlayerEntity player;
-    private Hand hand;
     private ItemStack backpackStack;
     int padding = 8;
     int titleSpace = 10;
     
     public BackpackScreenHandler(int synchronizationID, PlayerInventory playerInventory, PacketByteBuf packetByteBuf) {
-        this(synchronizationID, playerInventory, packetByteBuf.readEnumConstant(Hand.class));
+        this(synchronizationID, playerInventory, packetByteBuf.readItemStack());
     }
-    
-    public BackpackScreenHandler(int synchronizationID, PlayerInventory playerInventory, Hand hand) {
+
+    public BackpackScreenHandler(int synchronizationID, PlayerInventory playerInventory, ItemStack backpackStack) {
         super(Inmis.CONTAINER_TYPE, synchronizationID);
-        this.player = playerInventory.player;
-        this.hand = hand;
-        ItemStack backpackStack = player.getStackInHand(hand);
-        
+        this.backpackStack = backpackStack;
+
         if (backpackStack.getItem() instanceof BackpackItem) {
             setupContainer(playerInventory, backpackStack);
         } else {
+            PlayerEntity player = playerInventory.player;
             this.close(player);
         }
     }
@@ -82,7 +78,7 @@ public class BackpackScreenHandler extends ScreenHandler {
     }
     
     public BackpackItem getItem() {
-        return (BackpackItem) player.getStackInHand(hand).getItem();
+        return (BackpackItem) backpackStack.getItem();
     }
     
     public Dimension getDimension() {
@@ -102,8 +98,7 @@ public class BackpackScreenHandler extends ScreenHandler {
 
     @Override
     public boolean canUse(PlayerEntity player) {
-        ItemStack stackInHand = player.getStackInHand(this.hand);
-        return stackInHand.getItem() instanceof BackpackItem;
+        return backpackStack.getItem() instanceof BackpackItem;
     }
     
     @Override
@@ -139,12 +134,16 @@ public class BackpackScreenHandler extends ScreenHandler {
         
         @Override
         public boolean canTakeItems(PlayerEntity playerEntity) {
-            return !(getStack().getItem() instanceof BackpackItem) && getStack() != player.getStackInHand(hand);
+            return stackMovementIsAllowed(getStack());
         }
         
         @Override
         public boolean canInsert(ItemStack stack) {
-            return !(stack.getItem() instanceof BackpackItem) && stack != player.getStackInHand(hand);
+            return stackMovementIsAllowed(stack);
+        }
+
+        private boolean stackMovementIsAllowed(ItemStack stack) {
+            return !(stack.getItem() instanceof BackpackItem) && stack != backpackStack;
         }
     }
 }

--- a/src/main/resources/assets/inmis/lang/en_us.json
+++ b/src/main/resources/assets/inmis/lang/en_us.json
@@ -15,5 +15,8 @@
   "item.inmis.endless_backpack": "Endless Backpack",
 
   "inmis.advancement.baby_backpack.title": "Goody Bag",
-  "inmis.advancement.baby_backpack.description": "Perfect for party gifts!"
+  "inmis.advancement.baby_backpack.description": "Perfect for party gifts!",
+
+  "category.inmis.keybindings": "Inmis",
+  "key.inmis.open_backpack": "Open Backpack"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,8 @@
     ]
   },
   "mixins": [
-    "inmis.mixins.json"
+    "inmis.mixins.json",
+    "inmis.trinkets.mixins.json"
   ],
   "depends": {
     "fabricloader": ">=0.7.8+build.186",

--- a/src/main/resources/inmis.trinkets.mixins.json
+++ b/src/main/resources/inmis.trinkets.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "package": "draylar.inmis.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "trinkets.BackpackItemTrinketMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "plugin": "draylar.inmis.mixin.trinkets.TrinketsMixinPlugin"
+}

--- a/src/main/resources/inmis.trinkets.mixins.json
+++ b/src/main/resources/inmis.trinkets.mixins.json
@@ -1,9 +1,9 @@
 {
   "required": true,
-  "package": "draylar.inmis.mixin",
+  "package": "draylar.inmis.mixin.trinkets",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "trinkets.BackpackItemTrinketMixin"
+    "BackpackItemTrinketMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
1. Allows placement of any backpack into the backpack trinket slot if the [Trinkets](https://www.curseforge.com/minecraft/mc-mods/trinkets-fabric) mod is present
   - I added a `compileOnly` dependency on Trinkets
   - I used a plugin mixin to conditionally make `BackpackItem` implement `Trinket` when Trinkets is present
   - This adresses the second request in #51 

![image](https://user-images.githubusercontent.com/4239887/104138068-37553500-5367-11eb-9c3b-5751d06d1541.png)

2. Adds a keybinding to open the first backpack in the player's inventory
   - I had to refactor `BackpackScreenHandler` to not be tied to hands for this
   - This addresses the basics for #48, though I didn't go so far as enabling opening of different backpacks by hotkey
   - The search for the 'first' backpack happens in this order:
      1. The backpack slot of the trinket inventory, if present
      2. The player's offhand
      3. Player's hotbar, left to right
      4. Player's main inventory, top left to bottom right

I did my best to match code style & organization to what was already there and your other mods, but change anything as you see fit.

Note: I didn't bother with any rendering stuff while wearing the backpack.