### PR TITLE
Update support for Shulker Box Tooltip

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ archives_base_name = inmis
 # Dependencies
 trinkets_version = 3.0.0
 cloth_config_version = 5.0.34
-shulker_box_tooltip_version = 2.3.4-alpha.1+20w46a
+shulker_box_tooltip_version = 3.0.0-alpha.4+1.17

--- a/src/main/java/draylar/inmis/compat/InmisShulkerBoxTooltipCompat.java
+++ b/src/main/java/draylar/inmis/compat/InmisShulkerBoxTooltipCompat.java
@@ -1,25 +1,15 @@
 package draylar.inmis.compat;
 
 import com.misterpemodder.shulkerboxtooltip.api.ShulkerBoxTooltipApi;
-import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProvider;
+import com.misterpemodder.shulkerboxtooltip.api.provider.PreviewProviderRegistry;
 import com.misterpemodder.shulkerboxtooltip.impl.provider.EnderChestPreviewProvider;
 import draylar.inmis.Inmis;
-import net.minecraft.item.Item;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 public class InmisShulkerBoxTooltipCompat implements ShulkerBoxTooltipApi {
 
     @Override
-    public String getModId() {
-        return "inmis";
-    }
-
-    @Override
-    public void registerProviders(Map<PreviewProvider, List<Item>> previewProviders) {
-        previewProviders.put(new InmisPreviewProvider(), Inmis.BACKPACKS);
-        previewProviders.put(new EnderChestPreviewProvider(), Collections.singletonList(Inmis.ENDER_POUCH));
+    public void registerProviders(PreviewProviderRegistry registry) {
+        registry.register(Inmis.id("backpack"), new InmisPreviewProvider(), Inmis.BACKPACKS);
+        registry.register(Inmis.id("ender_pouch"), new EnderChestPreviewProvider(), Inmis.ENDER_POUCH);
     }
 }


### PR DESCRIPTION
Shulker Box Tooltip's API changed in v3.0.0 causing Inmis to crash when installed alongside newer versions of SBT.

This PR updates the dependency and uses the new API.