### PR TITLE
updating plugin for 1.17.1 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.8-SNAPSHOT'
+    id 'fabric-loom' version '0.9.+'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@
 org.gradle.jvmargs = -Xmx1G
 
 # Fabric Properties
-minecraft_version = 1.17-rc2
-yarn_mappings = 1.17-rc2+build.10
-loader_version = 0.11.3
-fabric_version = 0.34.9+1.17
+minecraft_version = 1.17.1
+yarn_mappings = 1.17.1+build.46
+loader_version = 0.11.6
+fabric_version = 0.39.2+1.17
 
 # Mod Properties
 mod_version = 2.3.1
@@ -13,6 +13,6 @@ maven_group = draylar.inmis
 archives_base_name = inmis
 
 # Dependencies
-trinkets_version = 3.0.0
-cloth_config_version = 5.0.34
-shulker_box_tooltip_version = 3.0.0-alpha.4+1.17
+trinkets_version = 3.0.2
+cloth_config_version = 5.0.38
+shulker_box_tooltip_version = 3.0.1+1.17

--- a/src/main/java/draylar/inmis/compat/InmisPreviewProvider.java
+++ b/src/main/java/draylar/inmis/compat/InmisPreviewProvider.java
@@ -21,7 +21,7 @@ public class InmisPreviewProvider implements PreviewProvider {
     @Override
     public List<ItemStack> getInventory(PreviewContext context) {
         List<ItemStack> stacks = new ArrayList<>();
-        NbtList inventoryTag = context.getStack().getOrCreateTag().getList("Inventory", NbtType.COMPOUND);
+        NbtList inventoryTag = context.getStack().getOrCreateNbt().getList("Inventory", NbtType.COMPOUND);
 
         inventoryTag.forEach(element -> {
             NbtCompound stackTag = (NbtCompound) element;

--- a/src/main/java/draylar/inmis/mixin/ShapedRecipeMixin.java
+++ b/src/main/java/draylar/inmis/mixin/ShapedRecipeMixin.java
@@ -31,8 +31,8 @@ public abstract class ShapedRecipeMixin {
             ItemStack newBackpack = this.getOutput().copy();
 
             if(newBackpack.getItem() instanceof BackpackItem) {
-                NbtList oldTag = centerSlot.getOrCreateTag().getList("Inventory", NbtType.COMPOUND);
-                newBackpack.getOrCreateTag().put("Inventory", oldTag);
+                NbtList oldTag = centerSlot.getOrCreateNbt().getList("Inventory", NbtType.COMPOUND);
+                newBackpack.getOrCreateNbt().put("Inventory", oldTag);
                 cir.setReturnValue(newBackpack);
             }
         }

--- a/src/main/java/draylar/inmis/ui/BackpackScreenHandler.java
+++ b/src/main/java/draylar/inmis/ui/BackpackScreenHandler.java
@@ -46,11 +46,11 @@ public class BackpackScreenHandler extends ScreenHandler {
         int rowWidth = tier.getRowWidth();
         int numberOfRows = tier.getNumberOfRows();
 
-        NbtList tag = backpackStack.getOrCreateTag().getList("Inventory", NbtType.COMPOUND);
+        NbtList tag = backpackStack.getOrCreateNbt().getList("Inventory", NbtType.COMPOUND);
         SimpleInventory inventory = new SimpleInventory(rowWidth * numberOfRows) {
             @Override
             public void markDirty() {
-                backpackStack.getOrCreateTag().put("Inventory", InventoryUtils.toTag(this));
+                backpackStack.getOrCreateNbt().put("Inventory", InventoryUtils.toTag(this));
                 super.markDirty();
             }
         };


### PR DESCRIPTION
Updated mappings accordingly for 1.17.1. Refactor of ItemStack in PR https://github.com/FabricMC/yarn/pull/2511 explains the change from getOrCreateTag() to getOrCreateNbt().